### PR TITLE
Fix "autoload.php" path in cli script

### DIFF
--- a/bin/uaparser.php
+++ b/bin/uaparser.php
@@ -4,7 +4,7 @@ namespace UAParser\Command;
 use Symfony\Component\Console\Application;
 
 $packageAutoloader = __DIR__ . '/../vendor/autoload.php';
-$standaloneAutoloader = __DIR__ . '/../../autoload.php';
+$standaloneAutoloader = __DIR__ . '/../../../autoload.php';
 if (file_exists($packageAutoloader)) {
     require_once $packageAutoloader;
 } else {


### PR DESCRIPTION
Wrong relative path of "autoload.php" is used in CLI script when it is used within an application. The PR fixes the problem.
