### PR TITLE
Move symfony dependencies to "suggest"

### DIFF
--- a/bin/uaparser
+++ b/bin/uaparser
@@ -2,6 +2,12 @@
 <?php
 namespace UAParser\Command;
 
+// Ensure symfony packages installed
+if (!class_exists(Symfony\Component\Console\Application::class)) {
+    echo 'You must include the symfony packages, see composer.json "suggest" section' . PHP_EOL;
+    exit(1);
+}
+
 use Symfony\Component\Console\Application;
 
 $packageAutoloader = __DIR__ . '/../vendor/autoload.php';

--- a/bin/uaparser
+++ b/bin/uaparser
@@ -2,14 +2,6 @@
 <?php
 namespace UAParser\Command;
 
-// Ensure symfony packages installed
-if (!class_exists(Symfony\Component\Console\Application::class)) {
-    echo 'You must include the symfony packages, see composer.json "suggest" section' . PHP_EOL;
-    exit(1);
-}
-
-use Symfony\Component\Console\Application;
-
 $packageAutoloader = __DIR__ . '/../vendor/autoload.php';
 $standaloneAutoloader = __DIR__ . '/../../../autoload.php';
 if (file_exists($packageAutoloader)) {
@@ -20,6 +12,14 @@ if (file_exists($packageAutoloader)) {
 
 $resourceDirectory = realpath(__DIR__ . '/../resources');
 $defaultYamlFile = realpath(__DIR__ . '/../resources/regexes.yaml');
+
+// Ensure symfony packages installed
+if (!class_exists(\Symfony\Component\Console\Application::class)) {
+    echo 'You must include the symfony packages, see composer.json "suggest" section' . PHP_EOL;
+    exit(1);
+}
+
+use \Symfony\Component\Console\Application;
 
 $application = new Application('ua-parser');
 $application->add(new ConvertCommand($resourceDirectory, $defaultYamlFile));

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,12 @@
         "symfony/finder": "^2.0 || ^3.0 || ^4.0",
         "symfony/console": "^2.0 || ^3.0 || ^4.0"
     },
+    "suggest": {
+        "symfony/yaml": "Required for CLI usage - ^4.0 || ^5.0",
+        "symfony/filesystem": "Required for CLI usage - 2.0 || ^3.0 || ^4.0",
+        "symfony/finder": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0",
+        "symfony/console": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0"",   
+    },
     "prefer-stable": true,
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/yaml": "Required for CLI usage, minimum version 2.0",
         "symfony/filesystem": "Required for CLI usage, minimum version 2.0",
         "symfony/finder": "Required for CLI usage, minimum version 2.0",
-        "symfony/console": "Required for CLI usage, minimum version 2.0",   
+        "symfony/console": "Required for CLI usage, minimum version 2.0"  
     },
     "prefer-stable": true,
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
         "phpunit/phpunit": "^4.0 || ^5.0"
     },
     "suggest": {
-        "symfony/yaml": "Required for CLI usage",
-        "symfony/filesystem": "Required for CLI usage",
-        "symfony/finder": "Required for CLI usage",
-        "symfony/console": "Required for CLI usage",   
+        "symfony/yaml": "Required for CLI usage, minimum version 2.0",
+        "symfony/filesystem": "Required for CLI usage, minimum version 2.0",
+        "symfony/finder": "Required for CLI usage, minimum version 2.0",
+        "symfony/console": "Required for CLI usage, minimum version 2.0",   
     },
     "prefer-stable": true,
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/yaml": "Required for CLI usage - ^4.0 || ^5.0",
         "symfony/filesystem": "Required for CLI usage - 2.0 || ^3.0 || ^4.0",
         "symfony/finder": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0",
-        "symfony/console": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0",   
+        "symfony/console": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0"   
     },
     "prefer-stable": true,
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,11 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0"
-    },
-    "suggest": {
-        "symfony/yaml": "Required for CLI usage, minimum version 2.0",
-        "symfony/filesystem": "Required for CLI usage, minimum version 2.0",
-        "symfony/finder": "Required for CLI usage, minimum version 2.0",
-        "symfony/console": "Required for CLI usage, minimum version 2.0"  
+        "phpunit/phpunit": "^4.0 || ^5.0",
+        "symfony/yaml": "^2.0 || ^3.0 || ^4.0",
+        "symfony/filesystem": "^2.0 || ^3.0 || ^4.0",
+        "symfony/finder": "^2.0 || ^3.0 || ^4.0",
+        "symfony/console": "^2.0 || ^3.0 || ^4.0"
     },
     "prefer-stable": true,
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/yaml": "Required for CLI usage - ^4.0 || ^5.0",
         "symfony/filesystem": "Required for CLI usage - 2.0 || ^3.0 || ^4.0",
         "symfony/finder": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0",
-        "symfony/console": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0"",   
+        "symfony/console": "Required for CLI usage - ^2.0 || ^3.0 || ^4.0",   
     },
     "prefer-stable": true,
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,16 @@
     "name": "ua-parser/uap-php",
     "description": "A multi-language port of Browserscope's user agent parser.",
     "require": {
-        "symfony/yaml": "^2.0 || ^3.0 || ^4.0",
-        "symfony/filesystem": "^2.0 || ^3.0 || ^4.0",
-        "symfony/finder": "^2.0 || ^3.0 || ^4.0",
-        "symfony/console": "^2.0 || ^3.0 || ^4.0",
         "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0"
+    },
+    "suggest": {
+        "symfony/yaml": "Required for CLI usage",
+        "symfony/filesystem": "Required for CLI usage",
+        "symfony/finder": "Required for CLI usage",
+        "symfony/console": "Required for CLI usage",   
     },
     "prefer-stable": true,
     "license": "MIT",


### PR DESCRIPTION
The symfony dependencies are only requires for CLI usage.
Move them to "suggest" so the library can be used without depending upon them.

Per https://github.com/ua-parser/uap-php/issues/43

Better still would be to make a new `cli` package that depends upon `uap-php` and remove symfony from this package entirely