### PR TITLE
Do not use PhpUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "composer/ca-bundle": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "<8",
         "symfony/yaml": "^2.0 || ^3.0 || ^4.0",
         "symfony/filesystem": "^2.0 || ^3.0 || ^4.0",
         "symfony/finder": "^2.0 || ^3.0 || ^4.0",


### PR DESCRIPTION
Phpunit 8 chages the signature of setUp and tearDown methods, so it makes harder to have a single test codebase across multiple Php versions. Suggest to skip that for the moment, while someone figures out a smart way to deal with that.