### PR TITLE
Allow running tests under PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "composer/ca-bundle": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "<8",
+        "phpunit/phpunit": "<9",
         "symfony/yaml": "^2.0 || ^3.0 || ^4.0",
         "symfony/filesystem": "^2.0 || ^3.0 || ^4.0",
         "symfony/finder": "^2.0 || ^3.0 || ^4.0",

--- a/tests/AbstractParserTest.php
+++ b/tests/AbstractParserTest.php
@@ -59,10 +59,10 @@ abstract class AbstractParserTest extends AbstractTestCase
         $method = $class->getMethod('getDefaultFile');
         $method->setAccessible(true);
 
-        $this->assertNotContains('..', $method->invoke(null));
+        $this->assertStringNotContainsString('..', $method->invoke(null));
     }
 
-    public function tearDown()
+    public function fcTearDown()
     {
         AbstractParser::$defaultFile = null;
     }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -9,31 +9,16 @@
 namespace UAParser\Test;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 
-abstract class AbstractTestCase extends TestCase
+if (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '8.0.0', '>=')) {
+    class_alias('UAParser\Test\AbstractTestCasePhpunit8', 'UAParser\Test\AbstractTestCaseCompatibility');
+} elseif (class_exists('PHPUnit\Runner\Version') && version_compare(Version::id(), '7.0.0', '>=')) {
+    class_alias('UAParser\Test\AbstractTestCasePhpunit7', 'UAParser\Test\AbstractTestCaseCompatibility');
+} else {
+    class_alias('UAParser\Test\AbstractTestCasePhpunit4', 'UAParser\Test\AbstractTestCaseCompatibility');
+}
+
+abstract class AbstractTestCase extends AbstractTestCaseCompatibility
 {
-    /**
-     * Compatibility layer for PHPUnit 6+ to support PHPUnit 4 code.
-     *
-     * @param mixed $class
-     *   The expected exception class.
-     * @param string $message
-     *   The expected exception message.
-     * @param int $exception_code
-     *   The expected exception code.
-     */
-    public function setExpectedException($class, $message = '', $exception_code = NULL)
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException($class);
-            if (!empty($message)) {
-                $this->expectExceptionMessage($message);
-            }
-            if ($exception_code !== NULL) {
-                $this->expectExceptionCode($exception_code);
-            }
-        } else {
-            parent::setExpectedException($class, $message, $exception_code);
-        }
-    }
 }

--- a/tests/AbstractTestCasePhpunit4.php
+++ b/tests/AbstractTestCasePhpunit4.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * ua-parser
+ *
+ * Copyright (c) 2011-2012 Dave Olsen, http://dmolsen.com
+ *
+ * Released under the MIT license
+ */
+namespace UAParser\Test;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestCasePhpunit4 extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        if (method_exists($this, 'fcSetUp')) {
+            $this->fcSetUp();
+        }
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        if (method_exists(get_called_class(), 'fcSetUpBeforeClass')) {
+            static::fcSetUpBeforeClass();
+        }
+    }
+
+    public function tearDown()
+    {
+        if (method_exists($this, 'fcTearDown')) {
+            $this->fcTearDown();
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Compatibility layer for PHPUnit 6+ to support PHPUnit 4 code.
+     *
+     * @param mixed $class
+     *   The expected exception class.
+     * @param string $message
+     *   The expected exception message.
+     * @param int $exception_code
+     *   The expected exception code.
+     */
+    public function setExpectedException($class, $message = '', $exception_code = NULL)
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($class);
+            if (!empty($message)) {
+                $this->expectExceptionMessage($message);
+            }
+            if ($exception_code !== NULL) {
+                $this->expectExceptionCode($exception_code);
+            }
+        } else {
+            parent::setExpectedException($class, $message, $exception_code);
+        }
+    }
+
+    public static function assertStringNotContainsString($needle, $haystack, $message = '')
+    {
+        parent::assertNotContains($needle, $haystack, $message);
+    }
+
+    public static function assertIsString($actual, $message = '')
+    {
+        parent::assertInternalType('string', $actual, $message);
+    }
+}

--- a/tests/AbstractTestCasePhpunit7.php
+++ b/tests/AbstractTestCasePhpunit7.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * ua-parser
+ *
+ * Copyright (c) 2011-2012 Dave Olsen, http://dmolsen.com
+ *
+ * Released under the MIT license
+ */
+namespace UAParser\Test;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestCasePhpunit7 extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        if (method_exists($this, 'fcSetUp')) {
+            $this->fcSetUp();
+        }
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        if (method_exists(static::class, 'fcSetUpBeforeClass')) {
+            static::fcSetUpBeforeClass();
+        }
+    }
+
+    public function tearDown()
+    {
+        if (method_exists($this, 'fcTearDown')) {
+            $this->fcTearDown();
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Compatibility layer for PHPUnit 7 to support PHPUnit 4 code.
+     *
+     * @param mixed $class
+     *   The expected exception class.
+     * @param string $message
+     *   The expected exception message.
+     * @param int $exception_code
+     *   The expected exception code.
+     */
+    public function setExpectedException($class, $message = '', $exception_code = NULL)
+    {
+        $this->expectException($class);
+        if (!empty($message)) {
+            $this->expectExceptionMessage($message);
+        }
+        if ($exception_code !== NULL) {
+            $this->expectExceptionCode($exception_code);
+        }
+    }
+}

--- a/tests/AbstractTestCasePhpunit8.php
+++ b/tests/AbstractTestCasePhpunit8.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * ua-parser
+ *
+ * Copyright (c) 2011-2012 Dave Olsen, http://dmolsen.com
+ *
+ * Released under the MIT license
+ */
+namespace UAParser\Test;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestCasePhpunit8 extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        if (method_exists($this, 'fcSetUp')) {
+            $this->fcSetUp();
+        }
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        if (method_exists(static::class, 'fcSetUpBeforeClass')) {
+            static::fcSetUpBeforeClass();
+        }
+    }
+
+    public function tearDown(): void
+    {
+        if (method_exists($this, 'fcTearDown')) {
+            $this->fcTearDown();
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Compatibility layer for PHPUnit 8 to support PHPUnit 4 code.
+     *
+     * @param mixed $class
+     *   The expected exception class.
+     * @param string $message
+     *   The expected exception message.
+     * @param int $exception_code
+     *   The expected exception code.
+     */
+    public function setExpectedException($class, $message = '', $exception_code = NULL)
+    {
+        $this->expectException($class);
+        if (!empty($message)) {
+            $this->expectExceptionMessage($message);
+        }
+        if ($exception_code !== NULL) {
+            $this->expectExceptionCode($exception_code);
+        }
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -21,12 +21,12 @@ class ParserTest extends AbstractParserTest
     /** @var Parser */
     private static $staticParser;
 
-    public static function setUpBeforeClass()
+    public static function fcSetUpBeforeClass()
     {
         static::$staticParser = Parser::create();
     }
 
-    public function setUp()
+    public function fcSetUp()
     {
         $this->parser = static::$staticParser;
     }

--- a/tests/Result/OperatingSystemTest.php
+++ b/tests/Result/OperatingSystemTest.php
@@ -16,7 +16,7 @@ class OperatingSystemTest extends AbstractTestCase
     /** @var UserAgent */
     private $userAgent;
 
-    public function setUp()
+    public function fcSetUp()
     {
         $this->userAgent = new UserAgent();
     }

--- a/tests/Result/UserAgentTest.php
+++ b/tests/Result/UserAgentTest.php
@@ -16,7 +16,7 @@ class UserAgentTest extends AbstractTestCase
     /** @var OperatingSystem */
     private $operatingSystem;
 
-    public function setUp()
+    public function fcSetUp()
     {
         $this->operatingSystem = new OperatingSystem();
     }

--- a/tests/Util/ConverterTest.php
+++ b/tests/Util/ConverterTest.php
@@ -30,7 +30,7 @@ class ConverterTest extends AbstractTestCase
     /** @var string */
     private $php;
 
-    public function setUp()
+    public function fcSetUp()
     {
         $this->fs = $this
             ->getMockBuilder('Symfony\Component\Filesystem\Filesystem')
@@ -61,7 +61,7 @@ EOS;
         touch($this->phpFile);
     }
 
-    public function tearDown()
+    public function fcTearDown()
     {
         @unlink($this->yamlFile);
         @unlink($this->phpFile);

--- a/tests/Util/FetcherTest.php
+++ b/tests/Util/FetcherTest.php
@@ -19,7 +19,7 @@ class FetcherTest extends AbstractTestCase
     public function testFetchSuccess()
     {
         $fetcher = new Fetcher();
-        $this->assertInternalType('string', $fetcher->fetch());
+        $this->assertIsString($fetcher->fetch());
     }
 
     public function testFetchError()

--- a/tests/Util/Logfile/ApacheCommonLogFormatReaderTest.php
+++ b/tests/Util/Logfile/ApacheCommonLogFormatReaderTest.php
@@ -12,7 +12,7 @@ use UAParser\Util\Logfile\ApacheCommonLogFormatReader;
 
 class ApacheCommonLogFormatReaderTest extends AbstractReaderTest
 {
-    public function setUp()
+    public function fcSetUp()
     {
         $this->reader = new ApacheCommonLogFormatReader();
 


### PR DESCRIPTION
It's possible to let tests run under PHPUnit 8 for PHP versions 7.2+

However, I acknowledge it's a bit complicated - you need to create compatibility layers for different PHPUnit versions, and load them conditionally based on the PHPUnit test runner version; further, you neeed to cater for forward compatibility for some methods that are getting deprecated.

Here's a PR that is based on similar work done for fileeye/mimemap that is itself inspired by similar work done in the Drupal project.

Alternatively, a new branch could do, with higher PHP requirements in the composer.json. But that obviously would mean increase maintenance work.