### PR TITLE
Exclude tests/ from Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/ export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Reduce size of composer package.
Also reduces noise when auditing packages between upgrades.