### PR TITLE
Load regex files only once per request

### DIFF
--- a/src/AbstractParser.php
+++ b/src/AbstractParser.php
@@ -60,7 +60,12 @@ abstract class AbstractParser
             throw $exceptionFactory($file);
         }
 
-        return new static(include $file);
+        static $map = [];
+        if (!isset($map[$file])) {
+            $map[$file] = include $file;
+        }
+
+        return new static($map[$file]);
     }
 
     protected static function tryMatch(array $regexes, string $userAgent): array


### PR DESCRIPTION
This memoized the contents of the regex file in a static property in the factory method to load only once per request.