### PR TITLE
Bugfix: handling null values in source yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.4.3
+- Bugfix: handling null values in source yaml file
+
 ## 3.4.2
  - Update uap-core
 

--- a/src/Util/CodeGenerator.php
+++ b/src/Util/CodeGenerator.php
@@ -25,11 +25,14 @@ class CodeGenerator
             return static function(string $source, array $element) use ($indentation, $multi, $createReducer) {
                 [$key, $value] = $element;
 
-                if (is_scalar($value)) {
-                    if ($multi) {
-                        $source .= self::indent($indentation);
-                    }
-                    $source .= self::generateKey($key) .  var_export($value, true);
+                if ($multi) {
+                    $source .= self::indent($indentation);
+                }
+
+                $source .= self::generateKey($key);
+
+                if (is_scalar($value) || is_null($value)) {
+                    $source .= var_export($value, true);
                     if ($multi) {
                         $source .= ",\n";
                     }
@@ -37,10 +40,7 @@ class CodeGenerator
                     return $source;
                 }
 
-                if ($multi) {
-                    $source .= self::indent($indentation);
-                }
-                $source .= self::generateKey($key) . "[";
+                $source .= "[";
                 $nextMulti = count($value) > 1;
                 if ($nextMulti) {
                     $source .= "\n";

--- a/tests/Util/CodeGeneratorTest.php
+++ b/tests/Util/CodeGeneratorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace UAParser\Test\Util;
+
+use Symfony\Component\Yaml\Yaml;
+use UAParser\Test\AbstractTestCase;
+use UAParser\Util\CodeGenerator;
+
+class CodeGeneratorTest extends AbstractTestCase
+{
+    public function testCodeGeneratorScalarAndNull(): void
+    {
+        $cg = new CodeGenerator();
+
+        $yamlString = <<<YML
+user_agent_parsers:
+  - regex: 'UaRegEx'
+
+os_parsers:
+  - regex: '(Windows 10)'
+    os_replacement: 'Windows'
+    os_v1_replacement: '10'
+
+device_parsers:
+  - regex: 'SomeDevice/'
+    brand_replacement: 'Some'
+    device_replacement: 'Device'
+    model_replacement: null
+YML;
+
+        $expected = [
+            'user_agent_parsers' => [[
+                'regex' => 'UaRegEx',
+            ]],
+            'os_parsers' => [[
+                'regex' => '(Windows 10)',
+                'os_replacement' => 'Windows',
+                'os_v1_replacement' => '10',
+            ]],
+            'device_parsers' => [[
+                'regex' => 'SomeDevice/',
+                'brand_replacement' => 'Some',
+                'device_replacement' => 'Device',
+                'model_replacement' => null,
+            ]]
+        ];
+
+        $rawPhp = $cg->generateArray(Yaml::parse($yamlString));
+        $evaluated = eval('return ' . $rawPhp);
+
+        $this->assertSame($expected, $evaluated);
+    }
+}


### PR DESCRIPTION
Recent Convertor stop working because of new NULL value appeared in source Yaml file with regexes.

This pull request fixes handling of null values. Test included