### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/src/Util/Converter.php
+++ b/src/Util/Converter.php
@@ -24,7 +24,7 @@ class Converter
     /** @var Filesystem */
     private $fs;
 
-    public function __construct(string $destination, CodeGenerator $codeGenerator = null, Filesystem $fs = null)
+    public function __construct(string $destination, ?CodeGenerator $codeGenerator = null, ?Filesystem $fs = null)
     {
         $this->destination = $destination;
         $this->codeGenerator = $codeGenerator ?: new CodeGenerator();

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -23,7 +23,7 @@ abstract class AbstractTestCase extends TestCase
      * @param int $exception_code
      *   The expected exception code.
      */
-    public function setExpectedException($class, string $message = '', int $exception_code = NULL): void
+    public function setExpectedException($class, string $message = '', ?int $exception_code = NULL): void
     {
         if (method_exists($this, 'expectException')) {
             $this->expectException($class);


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter
