### PR TITLE
Update README.md: Use composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 This is the PHP library for the [uap-core](https://github.com/ua-parser/uap-core) project.
 
 ## Installation ##
-Add `ua-parser/uap-php` to the require section of your `composer.json` file and run `composer update`.
+```
+composer require ua-parser/uap-php
+```
 
 ## Usage ##
 


### PR DESCRIPTION
Composer require command is the standard way to install composer packages. 

You should avoid modifying composer.json manually, as its more cumbersome, and you have to `composer update` at the end of it. This can lead to unwanted updates in other dependencies of the project.